### PR TITLE
add arm option to installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,8 @@ touch "$INSTALL_LOC" || { echo "ERROR: Cannot write to $GOSS_DST set GOSS_DST el
 arch=""
 if [ "$(uname -m)" = "x86_64" ]; then
     arch="amd64"
+elif [ "$(uname -m)" = "aarch64" ]; then
+    arch="arm"
 else
     arch="386"
 fi


### PR DESCRIPTION
Adds an ARM option to the Goss install script for easier installation on ARM systems.